### PR TITLE
Add custom http.client to avoid EOF errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# slab - CircleCI SLA Bot for Zendesk
+# slab - Zendesk SLA Bot for Slack
 
 This bot is a Go app that monitors a Zendesk instance and reports upcoming SLA breaches to a given Slack channel. 
 
@@ -15,35 +15,50 @@ The configuration `.toml` contains everything that SLAB needs in order to know w
 Within your configuration file, you should have this structure:
 
 ```
+UpdateFreq = "10m"
+LogLevel = "Debug"
 [Zendesk]
     User = "YOUR-ZENDESK-USERNAME"
     APIKey = "YOUR-ZENDESK-API-KEY"
     URL = "URL-TO-YOUR-ZENDESK-INSTANCE"
+[Slack]
+    APIKey="YOUR-API-KEY"
+    ChannelID="TARGET-CHANNEL-ID"
 [SLA]
     [SLA.LevelOne]
+        Tag = "platinum"
         Low = "8h"
         Normal = "4h"
         High = "1h"
         Urgent = "59m"
+        Notify = true
     [SLA.LevelTwo]
+        Tag = "gold"
         Low = "8h"
         Normal = "4h"
         High = "1h"
         Urgent = "59m"
+        Notify = true
     [SLA.LevelThree]
+        Tag = "silver"
         Low = "8h"
         Normal = "4h"
         High = "1h"
         Urgent = "59m"
+        Notify = true
     [SLA.LevelFour]
+        Tag = "standard"
         Low = "8h"
         Normal = "4h"
         High = "1h"
         Urgent = "59m"
-[Slack]
-    User = "YOUR-SLACK-USERNAME"
-    APIKey = "YOUR-SLACK-API-KEY"
-    URL = "URL-TO-YOUR-SLACK-INSTANCE"
+        Notify = false
+
 ```
 
-Zendesk user and API key can be found within the Settings of your Zendesk instance. More information can be found [here] on generating a Zendesk API key and username. SLA times are in the form of `8h`, `9m`, `1s`, etc. Up to 4 different SLA policies can be active at a given time. The Slack integration is done as part of a custom Slack integration that you must set up separately from this bot. Once that has been set up, your API information is used in the configuration to post messages to a given channel.
+`UpdateFreq` - in the form of `8h`, `9m`, `1s`, etc. Used to set the update loop. Default should be set to `10m`. 
+
+`LogLevel` - sets the log level output level. `debug` `info` and `notice` are valid options
+
+
+Zendesk user and API key can be found within the Settings of your Zendesk instance. More information can be found [here](https://support.zendesk.com/hc/en-us/articles/226022787-Generating-a-new-API-token-) on generating a Zendesk API key and username. SLA times are in the form of `8h`, `9m`, `1s`, etc. Up to 4 different SLA policies can be active at a given time. The Slack integration is done as part of a [bot user](https://api.slack.com/bot-users) in Slack. Once that has been set up, you're given a token for your bot. 

--- a/zendesk/api.go
+++ b/zendesk/api.go
@@ -109,8 +109,14 @@ func makeRequest(user string, key string, url string) (responseData []byte) {
 		os.Exit(1)
 	}
 	req.SetBasicAuth(user, key)
+	var netClient = &http.Client{
+		Timeout: time.Second * 10,
+		Transport: &http.Transport{
+			DisableKeepAlives: true,
+		},
+	}
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := netClient.Do(req)
 	if err != nil {
 		Log.Critical(err)
 		os.Exit(1)

--- a/zendesk/api.go
+++ b/zendesk/api.go
@@ -109,6 +109,9 @@ func makeRequest(user string, key string, url string) (responseData []byte) {
 		os.Exit(1)
 	}
 	req.SetBasicAuth(user, key)
+
+	// create custom http.Client to manually set timeout and disable keepalive
+	// in an attempt to avoid EOF errors
 	var netClient = &http.Client{
 		Timeout: time.Second * 10,
 		Transport: &http.Transport{


### PR DESCRIPTION
Instead of using the `http.DefaultClient` which doesn't have a timeout set and uses the default Transport, this creates a separate `http.Client` and sets a custom timeout and Transport. The custom Transport allows for the `KeepAlive` connections to be prevented, which should help remedy the EOF error found in #17.
