### PR TITLE
Merge tylerconlee/OnCall and SLAB

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@
 slab
 
 config.toml
+oncall-slab

--- a/log.go
+++ b/log.go
@@ -7,7 +7,7 @@ import (
 )
 
 var format = logging.MustStringFormatter(
-	`%{color}%{time:15:04:05.000} %{module} ▶ %{level:.4s} %{color:reset} %{message}`,
+	`%{color}%{time:2006-01-02T15:04:05.000} %{module} ▶ %{level:.4s} %{color:reset} %{message}`,
 )
 var errorFormatStr = logging.MustStringFormatter(
 	`%{color} %{longpkg} %{shortfunc} ▶ %{shortfile}`,

--- a/main.go
+++ b/main.go
@@ -8,7 +8,7 @@ import (
 
 	logging "github.com/op/go-logging"
 	"github.com/tylerconlee/slab/config"
-	"github.com/tylerconlee/slab/slack"
+	"github.com/tylerconlee/slab/server"
 )
 
 var log *logging.Logger
@@ -44,22 +44,25 @@ func main() {
 
 }
 
-func startServer() *slack.Server {
-	s := &slack.Server{
-		Info: &slack.ServerInfo{
+func startServer() *server.Server {
+	s := &server.Server{
+		Info: &server.ServerInfo{
 			Server:  "CircleCI-Support",
 			Version: Version,
 		},
 		Uptime: time.Now(),
 	}
 	go func() {
-		s.StartServer()
 		RunTimer(c.UpdateFreq.Duration)
+	}()
+	go func() {
+		s.StartServer()
+
 	}()
 	return s
 }
 
-func shutdown(ticker *time.Ticker, s *slack.Server) {
+func shutdown(ticker *time.Ticker, s *server.Server) {
 
 	if ticker != nil {
 		ticker.Stop()

--- a/main.go
+++ b/main.go
@@ -4,15 +4,17 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"time"
 
 	logging "github.com/op/go-logging"
 	"github.com/tylerconlee/slab/config"
+	"github.com/tylerconlee/slab/slack"
 )
 
 var log *logging.Logger
+var c config.Config
 
-// VERSION lists the version number. Attempts to follow SemVer
-// (http://semver.org/)
+// VERSION lists the version number. On build, uses the git hash as a version ID
 var (
 	Version = "undefined"
 )
@@ -25,9 +27,46 @@ func main() {
 	log.Notice("SLABot by Tyler Conlee")
 	log.Noticef("Version: %s", Version)
 
-	c := config.LoadConfig()
+	c = config.LoadConfig()
 	// Start timer process. Takes an int as the number of minutes to loop
-	RunTimer(c.UpdateFreq.Duration)
+
+	termChan := make(chan os.Signal, 1)
+	s := startServer()
+	ticker := time.NewTicker(time.Minute)
+	for {
+		select {
+		case <-ticker.C:
+
+		case <-termChan:
+			shutdown(ticker, s)
+		}
+	}
+
+}
+
+func startServer() *slack.Server {
+	s := &slack.Server{
+		Info: &slack.ServerInfo{
+			Server:  "CircleCI-Support",
+			Version: Version,
+		},
+		Uptime: time.Now(),
+	}
+	go func() {
+		s.StartServer()
+		RunTimer(c.UpdateFreq.Duration)
+	}()
+	return s
+}
+
+func shutdown(ticker *time.Ticker, s *slack.Server) {
+
+	if ticker != nil {
+		ticker.Stop()
+	}
+
+	log.Info("Shutdown complete.")
+	os.Exit(0)
 }
 
 func flagCheck() {

--- a/server/handler.go
+++ b/server/handler.go
@@ -1,4 +1,4 @@
-package slack
+package server
 
 import (
 	"encoding/json"
@@ -8,11 +8,13 @@ import (
 
 	"github.com/gorilla/mux"
 	logging "github.com/op/go-logging"
+	sl "github.com/tylerconlee/slab/slack"
 	"github.com/tylerconlee/slack"
 )
 
 // log adds a logger for the `api` package
-var log = logging.MustGetLogger("slack")
+var log = logging.MustGetLogger("server")
+var OnCall string
 
 // NewRouter builds a new mux Router instance with the routes that
 // Slack uses to handle callbacks, and the index status page
@@ -41,9 +43,10 @@ func (s *Server) SetOncall(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	log.Debug("Parsing action for callback")
-	if verifyUser(payload.Actions[0].SelectedOptions[0].Value) {
-		OnCall = payload.Actions[0].SelectedOptions[0].Value
-		ChatUpdate(payload.Channel.ID, payload.MessageTs, payload.Actions[0].SelectedOptions[0].Value)
+	if sl.VerifyUser(payload.Actions[0].SelectedOptions[0].Value) {
+		sl.OnCall = payload.Actions[0].SelectedOptions[0].Value
+		OnCall = sl.OnCall
+		sl.ChatUpdate(payload.Channel.ID, payload.MessageTs, payload.Actions[0].SelectedOptions[0].Value)
 	}
 	return
 }

--- a/server/handler.go
+++ b/server/handler.go
@@ -1,0 +1,81 @@
+package slack
+
+import (
+	"encoding/json"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/gorilla/mux"
+	logging "github.com/op/go-logging"
+	"github.com/tylerconlee/slack"
+)
+
+// log adds a logger for the `api` package
+var log = logging.MustGetLogger("slack")
+
+// NewRouter builds a new mux Router instance with the routes that
+// Slack uses to handle callbacks, and the index status page
+func (s *Server) NewRouter() *mux.Router {
+	log.Debug("Building Router")
+	r := mux.NewRouter()
+	r.HandleFunc("/slack", s.SetOncall).Methods("POST")
+	r.HandleFunc("/", s.Index).Methods("GET")
+	return r
+}
+
+// SetOncall is a handler that handles the callback from a Slack action.
+// TODO: Expand this to route to multiple callbacks, allowing for more
+// functionality
+func (s *Server) SetOncall(w http.ResponseWriter, r *http.Request) {
+	payload := &slack.AttachmentActionCallback{}
+
+	err := json.Unmarshal([]byte(r.PostFormValue("payload")), payload)
+	if err != nil {
+		log.Critical("Unable to parse JSON for callback payload")
+		os.Exit(1)
+	}
+
+	if len(payload.Actions) == 0 {
+		log.Debug(w, "missing action")
+		return
+	}
+	log.Debug("Parsing action for callback")
+	if verifyUser(payload.Actions[0].SelectedOptions[0].Value) {
+		OnCall = payload.Actions[0].SelectedOptions[0].Value
+		ChatUpdate(payload.Channel.ID, payload.MessageTs, payload.Actions[0].SelectedOptions[0].Value)
+	}
+	return
+}
+
+// Index is a handler that outputs the server metadata and uptime in JSON form.
+// TODO: add additional metadata for a more useful status page
+func (s *Server) Index(w http.ResponseWriter, r *http.Request) {
+	var status = ServerStatus{
+		ServerInfo: ServerInfo{
+			Server:  s.Info.Server,
+			Version: s.Info.Version,
+		},
+		Uptime: time.Now().Sub(s.Uptime).String(),
+	}
+
+	WriteJSON(w, &status, http.StatusOK)
+}
+
+// WriteJSON takes the ResponseWriter, a generic structure of data and a status
+// code and outputs it in JSON
+func WriteJSON(w http.ResponseWriter, info interface{}, status int) {
+	w.Header().Set("Content-Type", "application/json; charset=UTF-8")
+	w.Header().Set("Cache-Control", "no-store")
+
+	w.WriteHeader(status)
+
+	encoder := json.NewEncoder(w)
+	encoder.SetEscapeHTML(false)
+
+	if err := encoder.Encode(info); err != nil {
+		log.Debug("Failed to write JSON")
+	} else {
+		log.Debug(json.Marshal(info))
+	}
+}

--- a/server/server.go
+++ b/server/server.go
@@ -1,0 +1,42 @@
+package slack
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/gorilla/mux"
+)
+
+// Server is an overarching type that contains the router, the server
+// and any information displayed on the index page
+type Server struct {
+	Server *http.Server
+	Router *mux.Router
+	Info   *ServerInfo
+	Uptime time.Time
+}
+
+// ServerInfo is used on the index status page which shows the Server name and
+// the version of the bot
+type ServerInfo struct {
+	Server  string `json:"server"`
+	Version string `json:"version"`
+}
+
+// ServerStatus contains the metadata from ServerInfo as well as the uptime for
+// the bot
+type ServerStatus struct {
+	ServerInfo
+
+	Uptime string `json:"uptime"`
+}
+
+// StartServer loads a http.Server and starts the Slack monitor
+func (s *Server) StartServer() {
+	s.Router = s.NewRouter()
+
+	log.Info("HTTP server ready")
+	go StartSlack()
+	http.ListenAndServe(":8080", s.Router)
+
+}

--- a/server/server.go
+++ b/server/server.go
@@ -1,10 +1,11 @@
-package slack
+package server
 
 import (
 	"net/http"
 	"time"
 
 	"github.com/gorilla/mux"
+	sl "github.com/tylerconlee/slab/slack"
 )
 
 // Server is an overarching type that contains the router, the server
@@ -36,7 +37,7 @@ func (s *Server) StartServer() {
 	s.Router = s.NewRouter()
 
 	log.Info("HTTP server ready")
-	go StartSlack()
+	go sl.StartSlack()
 	http.ListenAndServe(":8080", s.Router)
 
 }

--- a/slack/notify.go
+++ b/slack/notify.go
@@ -3,12 +3,9 @@ package slack
 import (
 	"fmt"
 
-	logging "github.com/op/go-logging"
 	"github.com/tylerconlee/slab/config"
 	"github.com/tylerconlee/slab/zendesk"
 )
-
-var log = logging.MustGetLogger("slack")
 
 // PrepNotification takes a given ticket and what notification level and returns a string to be sent to Slack.
 func PrepNotification(ticket zendesk.ActiveTicket, notify int64) (notification string) {

--- a/slack/rtm.go
+++ b/slack/rtm.go
@@ -1,0 +1,211 @@
+package slack
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/tylerconlee/slack"
+)
+
+// api is an instance of the tylerconlee/slack Client
+var api *slack.Client
+
+// OnCall holds the User ID of the current person set as "OnCall"
+var OnCall string
+
+// StartSlack initializes a connection with the given slack instance, gets
+// team information, and starts a Go channel with the Real Time Messaging
+// API watcher.
+func StartSlack() {
+	log.Info("Starting connection to Slack")
+	// check to see if the Slack token and channel is part of the start up
+	if len(os.Args) < 3 {
+		log.Critical("Slack token missing. Ex: ./oncall-linux SLACK_TOKEN SLACK_CHANNEL")
+		os.Exit(1)
+	}
+	// start a connection to Slack using the Slack Bot token
+	api = slack.New(os.Args[1])
+
+	// retrieve the team info for the newly connected Slack team
+	d, err := api.GetTeamInfo()
+	if err != nil {
+		log.Critical(err)
+		os.Exit(1)
+	}
+	log.Info("Connected to Slack:", d.Domain)
+
+	// Set the initial value of OnCall
+	OnCall = "None"
+
+	// Start monitoring Slack
+	startRTM()
+
+}
+
+// SetMessage creates and sends a message to Slack with a menu attachment,
+// allowing users to set the OnCall staff member.
+func SetMessage() {
+	params := slack.PostMessageParameters{}
+	attachment := slack.Attachment{
+		Fallback:   "You would be able to select the oncall person here.",
+		CallbackID: "oncall_dropdown",
+		// Show the current OnCall member
+		Fields: []slack.AttachmentField{
+			slack.AttachmentField{
+				Title: "Currently OnCall",
+				Value: fmt.Sprintf("<@%s>", OnCall),
+			},
+		},
+		// Show a dropdown of all users to select new OnCall target
+		Actions: []slack.AttachmentAction{
+			slack.AttachmentAction{
+				Name:       "oncall_select",
+				Text:       "Select Team Member",
+				Type:       "select",
+				Style:      "primary",
+				DataSource: "users",
+			},
+		},
+	}
+
+	// Add the attachment to the parameters of a new message
+	params.Attachments = []slack.Attachment{attachment}
+
+	// Send a message to the given channel with pretext and the parameters
+	channelID, timestamp, err := api.PostMessage(os.Args[2], "...", params)
+	if err != nil {
+		fmt.Printf("%s\n", err)
+		return
+	}
+	// Log message if succesfully sent.
+	log.Infof("Set message successfully sent to channel %s at %s", channelID, timestamp)
+}
+
+// WhoIsMessage creates and sends a Slack message that sends out the value of
+// OnCall.
+func WhoIsMessage() {
+	params := slack.PostMessageParameters{}
+	attachment := slack.Attachment{
+		Fallback:   "You would be able to select the oncall person here.",
+		CallbackID: "oncall_dropdown",
+		// Show the current OnCall member
+		Fields: []slack.AttachmentField{
+			slack.AttachmentField{
+				Title: "Currently OnCall",
+				Value: fmt.Sprintf("<@%s>", OnCall),
+			},
+		},
+	}
+	params.Attachments = []slack.Attachment{attachment}
+	// Send a message to the given channel with pretext and the parameters
+	channelID, timestamp, err := api.PostMessage(os.Args[2], "...", params)
+	if err != nil {
+		fmt.Printf("%s\n", err)
+		return
+	}
+	// Send a message to the given channel with pretext and the parameters
+	log.Infof("WhoIs message successfully sent to channel %s at %s", channelID, timestamp)
+}
+
+// startRTM creates a separate Go channel which monitors the Slack instance.
+// The RTM tracks each and every event within Slack and allows the bot to act
+// accordingly.
+func startRTM() {
+	rtm := api.NewRTM()
+	chk := 0
+	var user *slack.User
+	var err error
+	go rtm.ManageConnection()
+
+	// When a new event occurs in Slack, track it here
+	for msg := range rtm.IncomingEvents {
+		switch ev := msg.Data.(type) {
+
+		// When a user connects to Slack for the first time. Logged message
+		// shows number of already connected users.
+		case *slack.ConnectedEvent:
+			log.Debug("Connection counter:", ev.ConnectionCount)
+
+		// If a new message is sent, check to see if the bot user is mentioned.
+		case *slack.MessageEvent:
+			if chk == 1 {
+				if strings.Contains(ev.Msg.Text, user.ID) {
+					parseCommand(ev.Msg.Text)
+				}
+			}
+
+		// On bot startup, the bot goes from Offline to Online, and is likely
+		// the first presence change for a bot that RTM will detect. Once
+		// detected, grab the ID for the bot user
+		case *slack.PresenceChangeEvent:
+			log.Debugf("Presence Change: %v\n", ev)
+			if chk == 0 {
+				user, err = api.GetUserInfo(ev.User)
+				if err != nil {
+					log.Critical(err)
+					os.Exit(1)
+				}
+				if user.Name == "oncall" && user.IsBot == true {
+					chk = 1
+				}
+
+			}
+		case *slack.RTMError:
+			log.Debugf("Error: %s\n", ev.Error())
+
+		case *slack.InvalidAuthEvent:
+			log.Debugf("Invalid credentials")
+			return
+
+		default:
+
+			// Ignore other events..
+			// fmt.Printf("Unexpected: %v\n", msg.Data)
+		}
+	}
+}
+
+// ChatUpdate takes a channel ID, a timestamp and message text
+// and updated the message in the given Slack channel at the given
+// timestamp with the given message text. Currently, it also updates the
+// attachment specifically for the Set message output.
+func ChatUpdate(channel string, ts string, text string) {
+	t := fmt.Sprintf("Updated OnCall person to <@%s>", text)
+	params := slack.PostMessageParameters{}
+	attachment := slack.Attachment{
+		Fallback:   "You would be able to select the oncall person here.",
+		CallbackID: "oncall_dropdown",
+		Footer:     t,
+		FooterIcon: "https://emojipedia-us.s3.amazonaws.com/thumbs/120/apple/114/white-heavy-check-mark_2705.png",
+	}
+	params.Attachments = []slack.Attachment{attachment}
+	text = "..."
+	// Send an update to the given channel with pretext and the parameters
+	channelID, timestamp, t, err := api.UpdateMessageWithParams(channel, ts, text, params)
+	log.Debug(channelID, timestamp, t, err)
+}
+
+// parseCommand takes the message that mentions the bot user and identifies
+// what the user is asking for.
+func parseCommand(text string) {
+	t := strings.Fields(text)
+	switch t[1] {
+	case "set":
+		SetMessage()
+	case "whois":
+		WhoIsMessage()
+	}
+
+}
+
+// verifyUser takes a User ID string and runs the Slack GetUserInfo request. If
+// the user exists, the function returns true.
+func verifyUser(user string) bool {
+	_, err := api.GetUserInfo(user)
+	if err != nil {
+		log.Critical(err)
+		os.Exit(1)
+	}
+	return true
+}

--- a/slack/rtm.go
+++ b/slack/rtm.go
@@ -19,13 +19,9 @@ var OnCall string
 // API watcher.
 func StartSlack() {
 	log.Info("Starting connection to Slack")
-	// check to see if the Slack token and channel is part of the start up
-	if len(os.Args) < 3 {
-		log.Critical("Slack token missing. Ex: ./oncall-linux SLACK_TOKEN SLACK_CHANNEL")
-		os.Exit(1)
-	}
 	// start a connection to Slack using the Slack Bot token
-	api = slack.New(os.Args[1])
+
+	api = slack.New(c.Slack.APIKey)
 
 	// retrieve the team info for the newly connected Slack team
 	d, err := api.GetTeamInfo()
@@ -73,7 +69,7 @@ func SetMessage() {
 	params.Attachments = []slack.Attachment{attachment}
 
 	// Send a message to the given channel with pretext and the parameters
-	channelID, timestamp, err := api.PostMessage(os.Args[2], "...", params)
+	channelID, timestamp, err := api.PostMessage(c.Slack.ChannelID, "...", params)
 	if err != nil {
 		fmt.Printf("%s\n", err)
 		return
@@ -99,7 +95,7 @@ func WhoIsMessage() {
 	}
 	params.Attachments = []slack.Attachment{attachment}
 	// Send a message to the given channel with pretext and the parameters
-	channelID, timestamp, err := api.PostMessage(os.Args[2], "...", params)
+	channelID, timestamp, err := api.PostMessage(c.Slack.ChannelID, "...", params)
 	if err != nil {
 		fmt.Printf("%s\n", err)
 		return
@@ -112,6 +108,7 @@ func WhoIsMessage() {
 // The RTM tracks each and every event within Slack and allows the bot to act
 // accordingly.
 func startRTM() {
+	log.Debug(api)
 	rtm := api.NewRTM()
 	chk := 0
 	var user *slack.User
@@ -201,7 +198,7 @@ func parseCommand(text string) {
 
 // verifyUser takes a User ID string and runs the Slack GetUserInfo request. If
 // the user exists, the function returns true.
-func verifyUser(user string) bool {
+func VerifyUser(user string) bool {
 	_, err := api.GetUserInfo(user)
 	if err != nil {
 		log.Critical(err)

--- a/slack/sla.go
+++ b/slack/sla.go
@@ -5,17 +5,20 @@ import (
 	"os"
 	"strings"
 
+	logging "github.com/op/go-logging"
 	"github.com/tylerconlee/slab/zendesk"
 
-	"github.com/nlopes/slack"
 	"github.com/tylerconlee/slab/config"
+	"github.com/tylerconlee/slack"
 )
 
-var c = config.LoadConfig()
+var (
+	c   = config.LoadConfig()
+	log = logging.MustGetLogger("slack")
+)
 
 // Send sends off the SLA notification to Slack using the configured API key
 func SendSLAMessage(n string, ticket zendesk.ActiveTicket) {
-	api := slack.New(c.Slack.APIKey)
 
 	color := "warning"
 

--- a/slack/sla.go
+++ b/slack/sla.go
@@ -14,7 +14,7 @@ import (
 var c = config.LoadConfig()
 
 // Send sends off the SLA notification to Slack using the configured API key
-func Send(n string, ticket zendesk.ActiveTicket) {
+func SendSLAMessage(n string, ticket zendesk.ActiveTicket) {
 	api := slack.New(c.Slack.APIKey)
 
 	color := "warning"

--- a/timer.go
+++ b/timer.go
@@ -25,7 +25,7 @@ func RunTimer(interval time.Duration) {
 				send, notify := sla.UpdateCache(ticket)
 				if send {
 					n := slack.PrepNotification(ticket, notify)
-					slack.Send(n, ticket)
+					slack.SendSLAMessage(n, ticket)
 				}
 			}
 		}


### PR DESCRIPTION
By merging SLAB and OnCall, this creates a single bot that's more manageable moving forward. It allows for the "oncall" person to eventually be notified of ticket creation. 

It also creates a status page for the bot, available at `localhost:8081`, which shows metadata about the status of the bot. This metadata can be expanded upon to show the status of connections to Zendesk and Slack, what channel is being monitored, and when the last loop of Zendesk tickets was analyzed. 