### PR TITLE
Add circleci config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,37 @@
+version: 2
+jobs:
+  build:
+    working_directory: ~/slab
+    docker:
+      - image: circleci/golang:1.8.1
+        environment:
+          GOPATH=/home/circleci/slab
+      
+    steps:
+      - checkout
+      - run: go get -t -d -v ./...
+      - run: go build -v
+      - save_cache:
+          key: src-{{ .Branch }}-{{ checksum "main.go" }}
+          paths:
+            - "src/"
+  test:
+    working_directory: ~/slab
+    docker:
+      - image: circleci/golang:1.8.1
+        environment:
+          GOPATH=/home/circleci/slab
+    parallelism: 2
+    steps:
+      - checkout
+      - restore_cache:
+          key: src-{{ .Branch }}-{{ checksum "main.go" }}
+      - run: go test -v
+workflows:
+  version: 2
+  build_and_test:
+    jobs:
+      - build
+      - test:
+          requires:
+            - build

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # slab - Zendesk SLA Bot for Slack
 
+
+[![CircleCI](https://circleci.com/gh/TylerConlee/slab.svg?style=svg)](https://circleci.com/gh/TylerConlee/slab)
+
 This bot is a Go app that monitors a Zendesk instance and reports upcoming SLA breaches to a given Slack channel. 
 
 ## Installation


### PR DESCRIPTION
While the test suite has yet to be flushed out (I know, I know), having each commit build on CircleCI will allow for expansion into deploying from CircleCI easier.