### PR TITLE
Port added to configuration

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -20,6 +20,7 @@ type Config struct {
 	UpdateFreq    Duration
 	TriageEnabled bool
 	Metadata      Metadata
+	Port          int
 }
 
 type Metadata struct {

--- a/main.go
+++ b/main.go
@@ -51,6 +51,7 @@ func startServer() *server.Server {
 		Info: &server.ServerInfo{
 			Server:  c.Metadata.Server,
 			Version: Version,
+			Port:    c.Port,
 		},
 		Uptime: time.Now(),
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"fmt"
 	"net/http"
 	"time"
 
@@ -22,6 +23,7 @@ type Server struct {
 type ServerInfo struct {
 	Server  string `json:"server"`
 	Version string `json:"version"`
+	Port    int    `json:"port"`
 }
 
 // ServerStatus contains the metadata from ServerInfo as well as the uptime for
@@ -38,6 +40,7 @@ func (s *Server) StartServer() {
 
 	log.Info("HTTP server ready")
 	go sl.StartSlack()
-	http.ListenAndServe(":8080", s.Router)
+	port := fmt.Sprintf(":%d", s.Info.Port)
+	http.ListenAndServe(port, s.Router)
 
 }


### PR DESCRIPTION
Allows for additional configuration options, including running multiple instances of SLAB on a single host.