### PR TITLE
Added title link to updated attachment

### DIFF
--- a/slack/callbacks.go
+++ b/slack/callbacks.go
@@ -32,6 +32,8 @@ func AcknowledgeSLA(payload *slack.AttachmentActionCallback) {
 	log.Debug("Ticket acknowledged")
 	t := fmt.Sprintf("<@%s> acknowledged this ticket", payload.User.Name)
 	attachment := slack.Attachment{
+		Title:      payload.OriginalMessage.Attachments[0].Title,
+		TitleLink:  payload.OriginalMessage.Attachments[0].TitleLink,
 		Fallback:   "User acknowledged a ticket.",
 		CallbackID: "sla",
 		Footer:     t,


### PR DESCRIPTION
Per #41, this restores the ticket title to the attachment ones the ticket has been acknowledged