### PR TITLE
Remove SLA package to simplify packages

### DIFF
--- a/main.go
+++ b/main.go
@@ -12,7 +12,7 @@ import (
 	logging "github.com/op/go-logging"
 	"github.com/tylerconlee/slab/config"
 	"github.com/tylerconlee/slab/server"
-	"github.com/tylerconlee/slab/sla"
+	"github.com/tylerconlee/slab/zendesk"
 )
 
 var log *logging.Logger
@@ -62,7 +62,7 @@ func startServer() *server.Server {
 		Uptime: time.Now(),
 	}
 	go func() {
-		sla.RunTimer(c.UpdateFreq.Duration)
+		zendesk.RunTimer(c.UpdateFreq.Duration)
 	}()
 	go func() {
 		s.StartServer()

--- a/slack/messages.go
+++ b/slack/messages.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	logging "github.com/op/go-logging"
-	"github.com/tylerconlee/slab/zendesk"
 
 	"github.com/tylerconlee/slab/config"
 	"github.com/tylerconlee/slack"
@@ -80,8 +79,19 @@ func WhoIsMessage() {
 	SendMessage(attachment, "...")
 }
 
+type Ticket struct {
+	ID          int
+	Subject     string
+	SLA         []interface{}
+	Tags        []string
+	Level       string
+	Priority    interface{}
+	CreatedAt   time.Time
+	Description string
+}
+
 // SLAMessage sends off the SLA notification to Slack using the configured API key
-func SLAMessage(n string, ticket zendesk.ActiveTicket) {
+func SLAMessage(n string, ticket Ticket) {
 	description := ticket.Description
 	if len(ticket.Description) > 100 {
 		description = description[0:100] + "..."

--- a/zendesk/analyzer.go
+++ b/zendesk/analyzer.go
@@ -4,11 +4,7 @@ import (
 	"os"
 	"reflect"
 	"time"
-
-	logging "github.com/op/go-logging"
 )
-
-var log = logging.MustGetLogger("sla")
 
 // Sent is a collection of all NotifySent tickets that is checked before each // notification is sent.
 var Sent = []NotifySent{}
@@ -29,7 +25,7 @@ func GetTimeRemaining(ticket ActiveTicket) (remain time.Time) {
 		if p["breach_at"] != nil {
 			breach, err := time.Parse(time.RFC3339, p["breach_at"].(string))
 			if nil != err {
-				log.Critical(err)
+				Log.Critical(err)
 				os.Exit(1)
 			}
 
@@ -81,7 +77,7 @@ func UpdateCache(ticket ActiveTicket) (bool, int64) {
 			f := s.FieldByName("ID")
 			if f.IsValid() {
 				if f.Interface() == ticket.ID && s.FieldByName("Type").Int() == notify {
-					log.Debug("Ticket", ticket.ID, ": `", ticket.Subject, "` has already received a notification: ", notify, ". Expires at", expire)
+					Log.Debug("Ticket", ticket.ID, ": `", ticket.Subject, "` has already received a notification: ", notify, ". Expires at", expire)
 					return false, 0
 				}
 
@@ -89,7 +85,7 @@ func UpdateCache(ticket ActiveTicket) (bool, int64) {
 
 		}
 		Sent = append(Sent, NotifySent{ticket.ID, notify, expire})
-		log.Debug("Ticket", ticket.ID, ": `", ticket.Subject, "` should receive a notification: ", notify, ". Expires at", expire)
+		Log.Debug("Ticket", ticket.ID, ": `", ticket.Subject, "` should receive a notification: ", notify, ". Expires at", expire)
 		return true, notify
 	}
 

--- a/zendesk/analyzer.go
+++ b/zendesk/analyzer.go
@@ -1,4 +1,4 @@
-package sla
+package zendesk
 
 import (
 	"os"
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	logging "github.com/op/go-logging"
-	"github.com/tylerconlee/slab/zendesk"
 )
 
 var log = logging.MustGetLogger("sla")
@@ -24,7 +23,7 @@ type NotifySent struct {
 
 // GetTimeRemaining takes an instance of a ticket and returns the value of the next SLA
 // breach.
-func GetTimeRemaining(ticket zendesk.ActiveTicket) (remain time.Time) {
+func GetTimeRemaining(ticket ActiveTicket) (remain time.Time) {
 	if len(ticket.SLA) >= 1 {
 		p := ticket.SLA[0].(map[string]interface{})
 		if p["breach_at"] != nil {
@@ -69,7 +68,7 @@ func GetNotifyType(remain time.Duration) (notifyType int64) {
 // for notifications is, and then checks to see if that ticket ID and
 // notification type have been sent already. If yes, it returns True,
 // indicating a notifcation needs to be sent.
-func UpdateCache(ticket zendesk.ActiveTicket) (bool, int64) {
+func UpdateCache(ticket ActiveTicket) (bool, int64) {
 	cleanCache()
 	expire := GetTimeRemaining(ticket)
 	notify := GetNotifyType(time.Until(expire))

--- a/zendesk/parser.go
+++ b/zendesk/parser.go
@@ -5,11 +5,11 @@ package zendesk
 import (
 	"time"
 
-	c "github.com/tylerconlee/slab/config"
+	"github.com/tylerconlee/slab/config"
 )
 
 // config loads the configuration
-var config = c.LoadConfig()
+var c = config.LoadConfig()
 
 // ActiveTicket is the individual ticket details for a ticket
 // that's nearing SLA breach. This is passed to the main function so the
@@ -28,7 +28,7 @@ type ActiveTicket struct {
 // CheckSLA will grab the tickets from GetAllTickets, parse the SLA fields and // compare them to the current time
 func CheckSLA() (sla []ActiveTicket) {
 
-	zenResp := GetAllTickets(config.Zendesk.User, config.Zendesk.APIKey, config.Zendesk.URL)
+	zenResp := GetAllTickets(c.Zendesk.User, c.Zendesk.APIKey, c.Zendesk.URL)
 
 	for _, ticket := range zenResp.Tickets {
 		priority := getPriorityLevel(ticket.Tags)
@@ -59,13 +59,13 @@ func CheckSLA() (sla []ActiveTicket) {
 func getPriorityLevel(tags []string) (priLvl string) {
 	for _, v := range tags {
 		switch v {
-		case config.SLA.LevelOne.Tag:
+		case c.SLA.LevelOne.Tag:
 			return "LevelOne"
-		case config.SLA.LevelTwo.Tag:
+		case c.SLA.LevelTwo.Tag:
 			return "LevelTwo"
-		case config.SLA.LevelThree.Tag:
+		case c.SLA.LevelThree.Tag:
 			return "LevelThree"
-		case config.SLA.LevelFour.Tag:
+		case c.SLA.LevelFour.Tag:
 			return "LevelFour"
 		}
 	}

--- a/zendesk/timer.go
+++ b/zendesk/timer.go
@@ -11,12 +11,12 @@ import (
 // grabs the latest tickets, checks for upcoming SLAs and send notifications if
 // appropriate
 func RunTimer(interval time.Duration) {
-	log.Info("Starting timer with ", interval, " intervals")
+	Log.Info("Starting timer with ", interval, " intervals")
 	t := time.NewTicker(interval)
 	for {
 		active := CheckSLA()
-		log.Info("Successfully grabbed and parsed tickets from Zendesk")
-		log.Info("Checking ticket notifications...")
+		Log.Info("Successfully grabbed and parsed tickets from Zendesk")
+		Log.Info("Checking ticket notifications...")
 		for _, ticket := range active {
 
 			if ticket.Priority != nil {
@@ -28,14 +28,14 @@ func RunTimer(interval time.Duration) {
 				}
 			}
 		}
-		log.Info("Ticket notifications sent. Returning to idle state.")
+		Log.Info("Ticket notifications sent. Returning to idle state.")
 		<-t.C
 	}
 }
 
 // PrepNotification takes a given ticket and what notification level and returns a string to be sent to Slack.
 func PrepNotification(ticket ActiveTicket, notify int64) (notification string) {
-	log.Debug("Preparing notification for", ticket.ID)
+	Log.Debug("Preparing notification for", ticket.ID)
 	var t, p string
 	var r bool
 

--- a/zendesk/timer.go
+++ b/zendesk/timer.go
@@ -1,13 +1,10 @@
-package sla
+package zendesk
 
 import (
 	"fmt"
 	"time"
 
-	"github.com/tylerconlee/slab/config"
 	"github.com/tylerconlee/slab/slack"
-
-	Zen "github.com/tylerconlee/slab/zendesk"
 )
 
 // RunTimer takes the interval from the config, and at each loop iteration,
@@ -17,7 +14,7 @@ func RunTimer(interval time.Duration) {
 	log.Info("Starting timer with ", interval, " intervals")
 	t := time.NewTicker(interval)
 	for {
-		active := Zen.CheckSLA()
+		active := CheckSLA()
 		log.Info("Successfully grabbed and parsed tickets from Zendesk")
 		log.Info("Checking ticket notifications...")
 		for _, ticket := range active {
@@ -26,7 +23,8 @@ func RunTimer(interval time.Duration) {
 				send, notify := UpdateCache(ticket)
 				if send {
 					n := PrepNotification(ticket, notify)
-					slack.SLAMessage(n, ticket)
+					m := slack.Ticket(ticket)
+					slack.SLAMessage(n, m)
 				}
 			}
 		}
@@ -36,9 +34,8 @@ func RunTimer(interval time.Duration) {
 }
 
 // PrepNotification takes a given ticket and what notification level and returns a string to be sent to Slack.
-func PrepNotification(ticket Zen.ActiveTicket, notify int64) (notification string) {
+func PrepNotification(ticket ActiveTicket, notify int64) (notification string) {
 	log.Debug("Preparing notification for", ticket.ID)
-	c := config.LoadConfig()
 	var t, p string
 	var r bool
 


### PR DESCRIPTION
The SLA package heavily relied on the Zendesk package and didn't provide any functions that were used by other packages, so merging it into the Zendesk package to simplify the imports should make maintenance easier moving forward.