### PR TITLE
Send notifications of new tickets to the Triager account

### DIFF
--- a/slack/messages.go
+++ b/slack/messages.go
@@ -21,7 +21,7 @@ var (
 
 // SendMessage takes an attachment and message and composes a message to be
 // sent to the configured Slack channel ID
-func SendMessage(attachment slack.Attachment, message string) {
+func SendMessage(message string, attachment slack.Attachment) {
 	params := slack.PostMessageParameters{}
 	params.Attachments = []slack.Attachment{attachment}
 	params.LinkNames = 1
@@ -59,7 +59,7 @@ func SetMessage() {
 			},
 		},
 	}
-	SendMessage(attachment, "...")
+	SendMessage("...", attachment)
 }
 
 // WhoIsMessage creates and sends a Slack message that sends out the value of
@@ -76,9 +76,11 @@ func WhoIsMessage() {
 			},
 		},
 	}
-	SendMessage(attachment, "...")
+	SendMessage("...", attachment)
 }
 
+// Ticket represents an individual ticket to be used in SLAMessage and
+// NewTicketMessage
 type Ticket struct {
 	ID          int
 	Subject     string
@@ -132,10 +134,41 @@ func SLAMessage(n string, ticket Ticket) {
 			},
 		},
 	}
-	SendMessage(attachment, n)
+	SendMessage(n, attachment)
 }
 
-func UpdateMessage() {
+// NewTicketMessage takes a slice of tickets that have been created in the last
+// loop interval and sends the IDs and links to the tickets to the user
+// currently set as triager.
+func NewTicketMessage(tickets []Ticket) {
+	var idlist []byte
+	var bl = 0
+
+	for _, ticket := range tickets {
+		bl += copy(
+			idlist[bl:],
+			fmt.Sprintf(
+				"%s/agent/tickets/%d",
+				c.Zendesk.URL,
+				ticket.ID,
+			),
+		)
+	}
+
+	message := fmt.Sprintf("The following tickets were received since the last loop: %x", idlist)
+
+	_, _, channelID, err := api.OpenIMChannel(Triager)
+
+	if err != nil {
+		fmt.Printf("%s\n", err)
+	}
+
+	api.PostMessage(channelID, message, slack.PostMessageParameters{})
+}
+
+// StatusMessage responds to @slab status with the version hash and current
+// uptime for the Slab process
+func StatusMessage() {
 	attachment := slack.Attachment{
 		Title: "Slab Status",
 		Fields: []slack.AttachmentField{
@@ -151,7 +184,7 @@ func UpdateMessage() {
 			},
 		},
 	}
-	SendMessage(attachment, "...")
+	SendMessage("...", attachment)
 }
 
 // ChatUpdate takes a channel ID, a timestamp and message text
@@ -186,7 +219,7 @@ func parseCommand(text string) {
 	case "whois":
 		WhoIsMessage()
 	case "status":
-		UpdateMessage()
+		StatusMessage()
 	}
 
 }

--- a/zendesk/analyzer.go
+++ b/zendesk/analyzer.go
@@ -25,7 +25,7 @@ func GetTimeRemaining(ticket ActiveTicket) (remain time.Time) {
 		if p["breach_at"] != nil {
 			breach, err := time.Parse(time.RFC3339, p["breach_at"].(string))
 			if nil != err {
-				Log.Critical(err)
+				log.Critical(err)
 				os.Exit(1)
 			}
 
@@ -77,7 +77,7 @@ func UpdateCache(ticket ActiveTicket) (bool, int64) {
 			f := s.FieldByName("ID")
 			if f.IsValid() {
 				if f.Interface() == ticket.ID && s.FieldByName("Type").Int() == notify {
-					Log.Debug("Ticket", ticket.ID, ": `", ticket.Subject, "` has already received a notification: ", notify, ". Expires at", expire)
+					log.Debug("Ticket", ticket.ID, ": `", ticket.Subject, "` has already received a notification: ", notify, ". Expires at", expire)
 					return false, 0
 				}
 
@@ -85,7 +85,7 @@ func UpdateCache(ticket ActiveTicket) (bool, int64) {
 
 		}
 		Sent = append(Sent, NotifySent{ticket.ID, notify, expire})
-		Log.Debug("Ticket", ticket.ID, ": `", ticket.Subject, "` should receive a notification: ", notify, ". Expires at", expire)
+		log.Debug("Ticket", ticket.ID, ": `", ticket.Subject, "` should receive a notification: ", notify, ". Expires at", expire)
 		return true, notify
 	}
 

--- a/zendesk/api.go
+++ b/zendesk/api.go
@@ -11,7 +11,7 @@ import (
 	"github.com/op/go-logging"
 )
 
-var Log = logging.MustGetLogger("zendesk")
+var log = logging.MustGetLogger("zendesk")
 
 // ZenOutput is the top level JSON-based struct that whatever is
 // returned by Zendesk goes into
@@ -84,18 +84,18 @@ type Tickets []struct {
 
 // GetAllTickets grabs the latest tickets from Zendesk and returns the JSON
 func GetAllTickets(user string, key string, url string) (tickets ZenOutput) {
-	Log.Info("Starting request to Zendesk for tickets")
+	log.Info("Starting request to Zendesk for tickets")
 
-	Log.Debugf("Zendesk API User Found: %s", user)
-	Log.Debugf("Zendesk API Key Found: %s", key)
+	log.Debugf("Zendesk API User Found: %s", user)
+	log.Debugf("Zendesk API Key Found: %s", key)
 
 	t := time.Now().AddDate(0, 0, -3).Unix()
-	Log.Debugf("Time: %d", t)
+	log.Debugf("Time: %d", t)
 	zenURL := url + "/api/v2/incremental/tickets.json?include=slas&start_time=" + strconv.FormatInt(t, 10)
-	Log.Debugf("URL: %s", zenURL)
+	log.Debugf("URL: %s", zenURL)
 	resp := makeRequest(user, key, zenURL)
 	tickets = parseJSON(resp)
-	Log.Info("Request Complete. Parsing Ticket Data for", len(tickets.Tickets), "tickets")
+	log.Info("Request Complete. Parsing Ticket Data for", len(tickets.Tickets), "tickets")
 
 	return tickets
 }
@@ -105,7 +105,7 @@ func GetAllTickets(user string, key string, url string) (tickets ZenOutput) {
 func makeRequest(user string, key string, url string) (responseData []byte) {
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
-		Log.Critical(err)
+		log.Critical(err)
 		os.Exit(1)
 	}
 	req.SetBasicAuth(user, key)
@@ -121,13 +121,13 @@ func makeRequest(user string, key string, url string) (responseData []byte) {
 
 	resp, err := netClient.Do(req)
 	if err != nil {
-		Log.Critical(err)
+		log.Critical(err)
 		os.Exit(1)
 	}
 	defer resp.Body.Close()
 	responseData, err = ioutil.ReadAll(resp.Body)
 	if err != nil {
-		Log.Critical(err)
+		log.Critical(err)
 		os.Exit(1)
 	}
 	return responseData
@@ -140,7 +140,7 @@ func parseJSON(data []byte) (output ZenOutput) {
 	bytes := json.RawMessage(data)
 	err := json.Unmarshal(bytes, &output)
 	if err != nil {
-		Log.Error("error:", err)
+		log.Error("error:", err)
 		os.Exit(1)
 	}
 	return output

--- a/zendesk/parser.go
+++ b/zendesk/parser.go
@@ -26,11 +26,9 @@ type ActiveTicket struct {
 }
 
 // CheckSLA will grab the tickets from GetAllTickets, parse the SLA fields and // compare them to the current time
-func CheckSLA() (sla []ActiveTicket) {
+func CheckSLA(tick ZenOutput) (sla []ActiveTicket) {
 
-	zenResp := GetAllTickets(c.Zendesk.User, c.Zendesk.APIKey, c.Zendesk.URL)
-
-	for _, ticket := range zenResp.Tickets {
+	for _, ticket := range tick.Tickets {
 		priority := getPriorityLevel(ticket.Tags)
 
 		if priority != "" {
@@ -52,6 +50,12 @@ func CheckSLA() (sla []ActiveTicket) {
 
 	}
 	return sla
+}
+
+// CheckNewTicket loops over the Zendesk output from GetAllTickets and
+// determines if there are tickets that have been created since the last loop
+func CheckNewTicket(tick ZenOutput, interval time.Duration) (ticket []ActiveTicket) {
+
 }
 
 // getPriorityLevel takes an individual ticket row from the Zendesk output and

--- a/zendesk/parser.go
+++ b/zendesk/parser.go
@@ -54,9 +54,24 @@ func CheckSLA(tick ZenOutput) (sla []ActiveTicket) {
 
 // CheckNewTicket loops over the Zendesk output from GetAllTickets and
 // determines if there are tickets that have been created since the last loop
-func CheckNewTicket(tick ZenOutput, interval time.Duration) (ticket []ActiveTicket) {
-
-	return ticket
+func CheckNewTicket(tick ZenOutput, interval time.Duration) (new []ActiveTicket) {
+	previousLoop := time.Now().Add(-interval)
+	nowLoop := time.Now()
+	for _, ticket := range tick.Tickets {
+		if ticket.CreatedAt.After(previousLoop) && ticket.CreatedAt.Before(nowLoop) {
+			t := ActiveTicket{
+				ID:          ticket.ID,
+				SLA:         ticket.Slas.PolicyMetrics,
+				Tags:        ticket.Tags,
+				Subject:     ticket.Subject,
+				Priority:    ticket.Priority,
+				CreatedAt:   ticket.CreatedAt,
+				Description: ticket.Description,
+			}
+			new = append(new, t)
+		}
+	}
+	return new
 }
 
 // getPriorityLevel takes an individual ticket row from the Zendesk output and

--- a/zendesk/parser.go
+++ b/zendesk/parser.go
@@ -42,10 +42,10 @@ func CheckSLA(tick ZenOutput) (sla []ActiveTicket) {
 				CreatedAt:   ticket.CreatedAt,
 				Description: ticket.Description,
 			}
-			Log.Debug("Ticket", ticket.ID, "successfully parsed. SLA found:", ticket.Slas.PolicyMetrics)
+			log.Debug("Ticket", ticket.ID, "successfully parsed. SLA found:", ticket.Slas.PolicyMetrics)
 			sla = append(sla, t)
 		} else {
-			Log.Debug("Ticket", ticket.ID, "successfully parsed.")
+			log.Debug("Ticket", ticket.ID, "successfully parsed.")
 		}
 
 	}
@@ -56,6 +56,7 @@ func CheckSLA(tick ZenOutput) (sla []ActiveTicket) {
 // determines if there are tickets that have been created since the last loop
 func CheckNewTicket(tick ZenOutput, interval time.Duration) (ticket []ActiveTicket) {
 
+	return ticket
 }
 
 // getPriorityLevel takes an individual ticket row from the Zendesk output and

--- a/zendesk/timer.go
+++ b/zendesk/timer.go
@@ -11,7 +11,7 @@ import (
 // grabs the latest tickets, checks for upcoming SLAs and send notifications if
 // appropriate
 func RunTimer(interval time.Duration) {
-	Log.Info("Starting timer with ", interval, " intervals")
+	log.Info("Starting timer with ", interval, " intervals")
 	t := time.NewTicker(interval)
 	for {
 		tick := GetAllTickets(
@@ -20,8 +20,8 @@ func RunTimer(interval time.Duration) {
 			c.Zendesk.URL,
 		)
 
-		Log.Info("Successfully grabbed and parsed tickets from Zendesk")
-		Log.Info("Checking ticket notifications...")
+		log.Info("Successfully grabbed and parsed tickets from Zendesk")
+		log.Info("Checking ticket notifications...")
 
 		// Returns a list of all upcoming SLA breaches
 		active := CheckSLA(tick)
@@ -42,14 +42,14 @@ func RunTimer(interval time.Duration) {
 			}
 		}
 
-		Log.Info("Ticket notifications sent. Returning to idle state.")
+		log.Info("Ticket notifications sent. Returning to idle state.")
 		<-t.C
 	}
 }
 
 // PrepSLANotification takes a given ticket and what notification level and returns a string to be sent to Slack.
 func PrepSLANotification(ticket ActiveTicket, notify int64) (notification string) {
-	Log.Debug("Preparing notification for", ticket.ID)
+	log.Debug("Preparing notification for", ticket.ID)
 	var t, p string
 	var r bool
 

--- a/zendesk/timer.go
+++ b/zendesk/timer.go
@@ -25,8 +25,6 @@ func RunTimer(interval time.Duration) {
 
 		// Returns a list of all upcoming SLA breaches
 		active := CheckSLA(tick)
-		// Returns a list of all new tickets within the last loop
-		new := CheckNewTicket(tick, interval)
 
 		// Loop through all active SLA tickets and prepare SLA notification
 		// for each.
@@ -42,10 +40,16 @@ func RunTimer(interval time.Duration) {
 			}
 		}
 
+		// Returns a list of all new tickets within the last loop
+		new := CheckNewTicket(tick, interval)
+		var newTickets []slack.Ticket
 		// Loop through all tickets and check
 		for _, ticket := range new {
+			m := slack.Ticket(ticket)
 
+			newTickets = append(newTickets, m)
 		}
+		slack.NewTicketMessage(newTickets)
 
 		log.Info("Ticket notifications sent. Returning to idle state.")
 		<-t.C

--- a/zendesk/timer.go
+++ b/zendesk/timer.go
@@ -42,6 +42,14 @@ func RunTimer(interval time.Duration) {
 			}
 		}
 
+		for _, ticket := range new {
+			previousLoop := time.Now().Add(-interval)
+			nowLoop := time.Now()
+			if ticket.CreatedAt.After(previousLoop) && ticket.CreatedAt.Before(nowLoop) {
+
+			}
+		}
+
 		log.Info("Ticket notifications sent. Returning to idle state.")
 		<-t.C
 	}

--- a/zendesk/timer.go
+++ b/zendesk/timer.go
@@ -28,7 +28,7 @@ func RunTimer(interval time.Duration) {
 		// Returns a list of all new tickets within the last loop
 		new := CheckNewTicket(tick, interval)
 
-		// Loop through all "active" SLA tickets and prepare SLA notification
+		// Loop through all active SLA tickets and prepare SLA notification
 		// for each.
 		for _, ticket := range active {
 
@@ -42,12 +42,9 @@ func RunTimer(interval time.Duration) {
 			}
 		}
 
+		// Loop through all tickets and check
 		for _, ticket := range new {
-			previousLoop := time.Now().Add(-interval)
-			nowLoop := time.Now()
-			if ticket.CreatedAt.After(previousLoop) && ticket.CreatedAt.Before(nowLoop) {
 
-			}
 		}
 
 		log.Info("Ticket notifications sent. Returning to idle state.")


### PR DESCRIPTION
In order for the triager role to actually make sense, they have to be made aware of when tickets are created. On each loop, any ticket with a CreatedAt field less than the loop will be sent to the UserID currently set as Triager. 