### PR TITLE
Add additional logging for new ticket notifications

### DIFF
--- a/zendesk/parser.go
+++ b/zendesk/parser.go
@@ -71,6 +71,7 @@ func CheckNewTicket(tick ZenOutput, interval time.Duration) (new []ActiveTicket)
 			new = append(new, t)
 		}
 	}
+	log.Debug("New Tickets: %x", new)
 	return new
 }
 

--- a/zendesk/timer.go
+++ b/zendesk/timer.go
@@ -46,7 +46,7 @@ func RunTimer(interval time.Duration) {
 		// Loop through all tickets and check
 		for _, ticket := range new {
 			m := slack.Ticket(ticket)
-
+			log.Debug("Adding new ticket to notification: %x", m)
 			newTickets = append(newTickets, m)
 		}
 		slack.NewTicketMessage(newTickets)

--- a/zendesk/timer.go
+++ b/zendesk/timer.go
@@ -43,7 +43,7 @@ func RunTimer(interval time.Duration) {
 		// Returns a list of all new tickets within the last loop
 		new := CheckNewTicket(tick, interval)
 		var newTickets []slack.Ticket
-		// Loop through all tickets and check
+		// Loop through all tickets and add to Slack package friendly slice
 		for _, ticket := range new {
 			m := slack.Ticket(ticket)
 			log.Debug("Adding new ticket to notification: %x", m)


### PR DESCRIPTION
To ensure that tickets are being recognized properly and sent as notifications, additional logging is required.