### PR TITLE
started first config wizard steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Tyler Conlee – [@TylerConlee](https://twitter.com/tylerconlee) – tyler@circl
 
 Distributed under the MIT license. See ``LICENSE`` for more information.
 
-[https://github.com/tylerconlee/](https://github.com/dbader/)
+[https://github.com/tylerconlee/](https://github.com/tylerconlee/)
 
 ## Contributing
 

--- a/server/handler.go
+++ b/server/handler.go
@@ -50,6 +50,14 @@ func (s *Server) Callback(w http.ResponseWriter, r *http.Request) {
 
 	case "triage_set":
 		sl.SetTriager(payload)
+	case "cfgwiz":
+		log.Info("Config wizard step detected", map[string]interface{}{
+			"module": "server",
+			"step":   payload.Actions[0].Value,
+		})
+		if payload.Actions[0].Value == "start" {
+			sl.NextStep("start")
+		}
 	}
 	return
 }

--- a/slack/channels.go
+++ b/slack/channels.go
@@ -1,0 +1,35 @@
+package slack
+
+type Channel struct {
+	ID string
+}
+
+var (
+	DMChannelList []Channel
+	ChannelList   []Channel
+)
+
+// GetChannel takes the event from RTM and determines if the channel is
+// part of a DM with a user that just initiated Slab, or if it's in a Slab
+// monitored channel.
+func getChannel(channel string) (chantype int) {
+	for _, c := range DMChannelList {
+		if channel == c.ID {
+			return 1
+		}
+	}
+	for _, c := range ChannelList {
+		if channel == c.ID {
+			return 2
+		}
+	}
+	return 0
+}
+
+func AddChannel(channel string, chantype int) {
+	if chantype == 1 {
+		DMChannelList = append(DMChannelList, Channel{ID: channel})
+	} else {
+		ChannelList = append(ChannelList, Channel{ID: channel})
+	}
+}

--- a/slack/channels.go
+++ b/slack/channels.go
@@ -1,12 +1,18 @@
 package slack
 
+// Channel represents an individual Slack channel, used either for DMs or
+// public usage, in which Slab has access to.
 type Channel struct {
 	ID string
 }
 
 var (
+	// DMChannelList is a collection of the individual DM channels that Slab
+	// has access to
 	DMChannelList []Channel
-	ChannelList   []Channel
+	// ChannelList is a collectoin of the individual channels that Slab has
+	// access to
+	ChannelList []Channel
 )
 
 // GetChannel takes the event from RTM and determines if the channel is
@@ -26,6 +32,9 @@ func getChannel(channel string) (chantype int) {
 	return 0
 }
 
+// AddChannel takes a channel and a channel type and adds it to the
+// corresponding list.
+// Types: 1 = DM Channel, 2 = Channel
 func AddChannel(channel string, chantype int) {
 	if chantype == 1 {
 		DMChannelList = append(DMChannelList, Channel{ID: channel})

--- a/slack/commands.go
+++ b/slack/commands.go
@@ -78,4 +78,13 @@ func parseCommand(text string, user string) {
 
 }
 
-func parseDMCommand(text string, user string) {}
+func parseDMCommand(text string, user string) {
+	t := strings.ToLower(text)
+	switch t {
+	case "start config":
+		StartWizard(user)
+	default:
+		UnknownCommandMessage(text, user)
+	}
+
+}

--- a/slack/commands.go
+++ b/slack/commands.go
@@ -24,14 +24,6 @@ func parseCommand(text string, user string) {
 		HelpMessage()
 	case "unset":
 		UnsetMessage()
-	case "config":
-		switch t[2] {
-		case "show":
-			ShowConfigMessage(user)
-		case "setup":
-			ConfigSetupMessage(user)
-		}
-
 	case "twilio":
 		p := plugins.LoadPlugins(c)
 		switch t[2] {

--- a/slack/commands.go
+++ b/slack/commands.go
@@ -77,3 +77,5 @@ func parseCommand(text string, user string) {
 	}
 
 }
+
+func parseDMCommand(text string, user string) {}

--- a/slack/commands.go
+++ b/slack/commands.go
@@ -28,7 +28,10 @@ func parseCommand(text string, user string) {
 		switch t[2] {
 		case "show":
 			ShowConfigMessage(user)
+		case "setup":
+			ConfigSetupMessage(user)
 		}
+
 	case "twilio":
 		p := plugins.LoadPlugins(c)
 		switch t[2] {

--- a/slack/messages.go
+++ b/slack/messages.go
@@ -376,6 +376,8 @@ func ShowConfigMessage(user string) {
 
 }
 
+// UnknownCommandMessage sends a direct message to the user provided indicating
+// that the command that they attempted is not a valid command.
 func UnknownCommandMessage(text string, user string) {
 	message := fmt.Sprintf("Sorry, the command `%s` is an invalid command. Please type `help` for a list of all available DM commands", text)
 	attachment := slack.Attachment{}

--- a/slack/messages.go
+++ b/slack/messages.go
@@ -376,6 +376,12 @@ func ShowConfigMessage(user string) {
 
 }
 
+func UnknownCommandMessage(text string, user string) {
+	message := fmt.Sprintf("Sorry, the command `%s` is an invalid command. Please type `help` for a list of all available DM commands", text)
+	attachment := slack.Attachment{}
+	SendDirectMessage(message, attachment, user)
+}
+
 // ChatUpdate takes a channel ID, a timestamp and message text
 // and updated the message in the given Slack channel at the given
 // timestamp with the given message text. Currently, it also updates the

--- a/slack/rtm.go
+++ b/slack/rtm.go
@@ -104,6 +104,10 @@ func startRTM() {
 				// the configuration step the user is currently in.
 				c := getChannel(ev.Channel)
 				if c == 1 {
+
+					// Run check to see if user is in configuration wizard
+					// if yes, run Next Step(), otherwise send a DM indicating
+					// that the configuration is already being edited.
 					if activeWizard {
 						if ev.User == activeUser.user {
 							nextStep()
@@ -111,13 +115,12 @@ func startRTM() {
 							ConfigInProgressMessage(ev.User)
 						}
 					} else {
+						// Otherwise, parse DM command, such as twilio, so that
+						// phone numbers aren't shared in public channels
+						// Leave open for future expansion
 						parseDMCommand(ev.Msg.Text, ev.User)
 					}
-					// Run check to see if user is in configuration wizard
-					// if yes, run Next Step()
-					// Otherwise, parse DM command, such as twilio, so that
-					// phone numbers aren't shared in public channels
-					// Leave open for future expansion
+
 				} else if c == 2 {
 					if strings.Contains(ev.Msg.Text, user.ID) {
 						parseCommand(ev.Msg.Text, ev.User)

--- a/slack/rtm.go
+++ b/slack/rtm.go
@@ -98,7 +98,7 @@ func startRTM() {
 		// If a new message is sent, check to see if the bot user is mentioned.
 		case *slack.MessageEvent:
 			if chk == 1 {
-				if strings.Contains(ev.Msg.Text, user.ID) && c.TriageEnabled {
+				if strings.Contains(ev.Msg.Text, user.ID) {
 					parseCommand(ev.Msg.Text, ev.User)
 				}
 			}

--- a/slack/rtm.go
+++ b/slack/rtm.go
@@ -110,7 +110,7 @@ func startRTM() {
 					// that the configuration is already being edited.
 					if activeWizard {
 						if ev.User == activeUser.user {
-							nextStep()
+							NextStep(ev.Msg.Text)
 						} else {
 							ConfigInProgressMessage(ev.User)
 						}

--- a/slack/rtm.go
+++ b/slack/rtm.go
@@ -98,6 +98,11 @@ func startRTM() {
 		// If a new message is sent, check to see if the bot user is mentioned.
 		case *slack.MessageEvent:
 			if chk == 1 {
+				// GetChannelList to see if the incoming message comes from DM
+				// or regular channel. If DM, identify the user and if they're
+				// in the middle of the configuration routine. Then identify
+				// the configuration step the user is currently in.
+
 				if strings.Contains(ev.Msg.Text, user.ID) {
 					parseCommand(ev.Msg.Text, ev.User)
 				}

--- a/slack/rtm.go
+++ b/slack/rtm.go
@@ -102,9 +102,26 @@ func startRTM() {
 				// or regular channel. If DM, identify the user and if they're
 				// in the middle of the configuration routine. Then identify
 				// the configuration step the user is currently in.
-
-				if strings.Contains(ev.Msg.Text, user.ID) {
-					parseCommand(ev.Msg.Text, ev.User)
+				c := getChannel(ev.Channel)
+				if c == 1 {
+					if activeWizard {
+						if ev.User == activeUser.user {
+							nextStep()
+						} else {
+							ConfigInProgressMessage(ev.User)
+						}
+					} else {
+						parseDMCommand(ev.Msg.Text, ev.User)
+					}
+					// Run check to see if user is in configuration wizard
+					// if yes, run Next Step()
+					// Otherwise, parse DM command, such as twilio, so that
+					// phone numbers aren't shared in public channels
+					// Leave open for future expansion
+				} else if c == 2 {
+					if strings.Contains(ev.Msg.Text, user.ID) {
+						parseCommand(ev.Msg.Text, ev.User)
+					}
 				}
 			}
 

--- a/slack/wizard.go
+++ b/slack/wizard.go
@@ -12,6 +12,13 @@ type configUser struct {
 	step string
 }
 
+// StartWizard takes the user ID, sets the configUser and starts the
+// ConfigSetupMessage function
+func StartWizard(user string) {
+	activeUser.user = user
+	ConfigSetupMessage(user)
+}
+
 // ConfigInProgressMessage takes a user ID string and sends a message to that
 // user letting them know that there's already a configuration wizard in
 // progress to avoid overlap.
@@ -25,7 +32,6 @@ func ConfigInProgressMessage(user string) {
 // the configuration setup wizard process.
 func ConfigSetupMessage(user string) {
 	activeUser.step = "1"
-	activeUser.user = user
 	message := "Hi! Let's get Slab set up! First, how many channels need access?"
 	attachment := slack.Attachment{
 		Title: "Number of Channels",

--- a/slack/wizard.go
+++ b/slack/wizard.go
@@ -1,7 +1,67 @@
 package slack
 
+import "github.com/tylerconlee/slack"
+
+var (
+	activeWizard bool
+	activeUser   configUser
+)
+
+type configUser struct {
+	user string
+	step string
+}
+
+func ConfigInProgressMessage(user string) {}
+
 // ConfigSetupMessage sends the first message to the specified user to start
 // the configuration setup wizard process.
 func ConfigSetupMessage(user string) {
+	activeUser.step = "1"
+	activeUser.user = user
+	message := "Hi! Let's get Slab set up! First, how many channels need access?"
+	attachment := slack.Attachment{
+		Title: "Number of Channels",
+		Actions: []slack.AttachmentAction{
+			slack.AttachmentAction{
+				Name: "channels_list",
+				Text: "Channel for Slab",
+				Type: "select",
+				Options: []slack.AttachmentActionOption{
+					slack.AttachmentActionOption{
+						Text:  "1",
+						Value: "1",
+					},
+					slack.AttachmentActionOption{
+						Text:  "2",
+						Value: "2",
+					},
+					slack.AttachmentActionOption{
+						Text:  "3",
+						Value: "3",
+					},
+				},
+			},
+		},
+	}
+	SendDirectMessage(message, attachment, user)
+}
+
+func ChannelSelectMessage(user string) {
+	attachment := slack.Attachment{
+		Title: "Channels",
+		Actions: []slack.AttachmentAction{
+			slack.AttachmentAction{
+				Name:       "channels_list",
+				Text:       "Channel for Slab",
+				Type:       "select",
+				DataSource: "channels",
+			},
+		},
+	}
+	SendDirectMessage("Select a channel", attachment, user)
+}
+
+func nextStep() {
 
 }

--- a/slack/wizard.go
+++ b/slack/wizard.go
@@ -1,0 +1,7 @@
+package slack
+
+// ConfigSetupMessage sends the first message to the specified user to start
+// the configuration setup wizard process.
+func ConfigSetupMessage(user string) {
+
+}

--- a/slack/wizard.go
+++ b/slack/wizard.go
@@ -12,6 +12,9 @@ type configUser struct {
 	step string
 }
 
+// ConfigInProgressMessage takes a user ID string and sends a message to that
+// user letting them know that there's already a configuration wizard in
+// progress to avoid overlap.
 func ConfigInProgressMessage(user string) {}
 
 // ConfigSetupMessage sends the first message to the specified user to start
@@ -47,6 +50,8 @@ func ConfigSetupMessage(user string) {
 	SendDirectMessage(message, attachment, user)
 }
 
+// ChannelSelectMessage takes a user string and sends that user a direct message
+// asking for a channel to be selected that Slab will monitor/send alerts to.
 func ChannelSelectMessage(user string) {
 	attachment := slack.Attachment{
 		Title: "Channels",

--- a/slack/wizard.go
+++ b/slack/wizard.go
@@ -15,7 +15,11 @@ type configUser struct {
 // ConfigInProgressMessage takes a user ID string and sends a message to that
 // user letting them know that there's already a configuration wizard in
 // progress to avoid overlap.
-func ConfigInProgressMessage(user string) {}
+func ConfigInProgressMessage(user string) {
+	message := "Oops! The configuration wizard is currently being used by another user. Please try again later."
+	attachment := slack.Attachment{}
+	SendDirectMessage(message, attachment, user)
+}
 
 // ConfigSetupMessage sends the first message to the specified user to start
 // the configuration setup wizard process.


### PR DESCRIPTION
Processes initial slack command to start Slab config wizard. Should log initial contact, return a message with 2 buttons and start actual config wizard after the start button is pressed.