### PR TITLE
add ability to filter messages to groups based on tags

### DIFF
--- a/datastore/settings.go
+++ b/datastore/settings.go
@@ -95,7 +95,7 @@ func SaveChannels(channelID string, private bool) (err error) {
 		return err
 	}
 
-	err = db.QueryRow("INSERT INTO channels(channel_id, private, updated_at) VALUES ($1, $2, $3) RETURNING id ON CONFLICT (channel_id) DO NOTHING;", channelID, private, time.Now()).Scan(&id)
+	err = db.QueryRow("INSERT INTO channels(channel_id, private, updated_at) VALUES ($1, $2, $3) RETURNING id;", channelID, private, time.Now()).Scan(&id)
 	log.Debug("Saved channel to database", map[string]interface{}{
 		"module": "datastore",
 		"data":   channelID,

--- a/datastore/tags.go
+++ b/datastore/tags.go
@@ -13,6 +13,7 @@ func CreateTagsTable() {
 		id serial PRIMARY KEY,
 		tag text NOT NULL,
 		userid text NOT NULL,
+		groupid text NOT NULL,
 		channel text NOT NULL,
 		notify_type text NOT NULL,
 		created_at timestamp,
@@ -38,7 +39,7 @@ func SaveNewTag(data map[string]string) error {
 		"module": "datastore",
 		"data":   data,
 	})
-	err := db.QueryRow("INSERT INTO tags(tag, userid, channel, notify_type, created_at, updated_at) VALUES ($1, $2, $3, $4, $5, $6) RETURNING id", data["tag"], data["user"], data["channel"], data["notify_type"], time.Now(), time.Now()).Scan(&id)
+	err := db.QueryRow("INSERT INTO tags(tag, userid, groupid, channel, notify_type, created_at, updated_at) VALUES ($1, $2, $3, $4, $5, $6, $7) RETURNING id", data["tag"], data["user"], data["group"], data["channel"], data["notify_type"], time.Now(), time.Now()).Scan(&id)
 	return err
 }
 
@@ -48,7 +49,7 @@ func SaveTagUpdate(data map[string]string) error {
 		"module": "datastore",
 		"data":   data,
 	})
-	err := db.QueryRow("UPDATE tags SET tag = $1, userid = $2, channel = $3, notify_type = $4, updated_at = $5 WHERE id = $6", data["tag"], data["user"], data["channel"], data["notify_type"], time.Now(), data["id"]).Scan(&id)
+	err := db.QueryRow("UPDATE tags SET tag = $1, userid = $2, groupid = $3, channel = $4, notify_type = $5, updated_at = $6 WHERE id = $7", data["tag"], data["user"], data["group"], data["channel"], data["notify_type"], time.Now(), data["id"]).Scan(&id)
 	return err
 }
 
@@ -70,7 +71,7 @@ func LoadTags() (tags []map[string]interface{}) {
 	log.Info("Requesting tags from database", map[string]interface{}{
 		"module": "datastore",
 	})
-	rows, err := db.Query("SELECT id, tag, userid, channel, notify_type, created_at, updated_at FROM tags WHERE id > 0")
+	rows, err := db.Query("SELECT id, tag, userid, groupid, channel, notify_type, created_at, updated_at FROM tags WHERE id > 0")
 	if err != nil {
 		log.Error("Error grabbing database output for tags", map[string]interface{}{
 			"module": "datastore",
@@ -84,13 +85,14 @@ func LoadTags() (tags []map[string]interface{}) {
 			id         int64
 			tag        string
 			user       string
+			group      string
 			channel    string
 			notifyType string
 			createdAt  string
 			updatedAt  string
 		)
 
-		if err := rows.Scan(&id, &tag, &user, &channel, &notifyType, &createdAt, &updatedAt); err != nil {
+		if err := rows.Scan(&id, &tag, &user, &group, &channel, &notifyType, &createdAt, &updatedAt); err != nil {
 			log.Error("Error parsing database output for tags", map[string]interface{}{
 				"module": "datastore",
 				"error":  err,
@@ -101,6 +103,7 @@ func LoadTags() (tags []map[string]interface{}) {
 			"id":          id,
 			"tag":         tag,
 			"user":        user,
+			"group":       group,
 			"channel":     channel,
 			"notify_type": notifyType,
 			"created_at":  createdAt,
@@ -117,7 +120,7 @@ func LoadTag(id int) (loadedTag map[string]interface{}) {
 		"module": "datastore",
 		"tag":    id,
 	})
-	rows, err := db.Query("SELECT id, tag, userid, channel, notify_type, created_at, updated_at FROM tags WHERE id = $1", id)
+	rows, err := db.Query("SELECT id, tag, userid, group, channel, notify_type, created_at, updated_at FROM tags WHERE id = $1", id)
 	if err != nil {
 		log.Error("Error grabbing database output for tags", map[string]interface{}{
 			"module": "datastore",
@@ -131,13 +134,14 @@ func LoadTag(id int) (loadedTag map[string]interface{}) {
 			id         int64
 			tag        string
 			user       string
+			group      string
 			channel    string
 			notifyType string
 			createdAt  string
 			updatedAt  string
 		)
 
-		if err := rows.Scan(&id, &tag, &user, &channel, &notifyType, &createdAt, &updatedAt); err != nil {
+		if err := rows.Scan(&id, &tag, &user, &group, &channel, &notifyType, &createdAt, &updatedAt); err != nil {
 			log.Error("Error parsing database output for tags", map[string]interface{}{
 				"module": "datastore",
 				"error":  err,
@@ -148,6 +152,7 @@ func LoadTag(id int) (loadedTag map[string]interface{}) {
 			"id":          id,
 			"tag":         tag,
 			"user":        user,
+			"group":       group,
 			"channel":     channel,
 			"notify_type": notifyType,
 			"created_at":  createdAt,

--- a/process.go
+++ b/process.go
@@ -122,7 +122,7 @@ func processSLAAlerts(tick zendesk.ZenOutput, tags []map[string]interface{}, p p
 							"channel": tag["channel"].(string),
 						})
 						m := slack.Ticket(ticket)
-						n, c := slack.PrepSLANotification(m, notify, tag["tag"].(string))
+						n, c := slack.PrepSLANotification(m, notify, tag["tag"].(string), tag["group"].(string))
 						p.SendDispatcher(n)
 						user := zendesk.GetTicketRequester(int(ticket.Requester))
 						org := getOrgName(ticket.ID)

--- a/process.go
+++ b/process.go
@@ -40,11 +40,11 @@ func iteration(t *time.Ticker, interval time.Duration) {
 	p := plugins.LoadPlugins()
 
 	if c.Slack.ChannelID != "" {
-		channel := slack.GetChannel(c.Slack.ChannelID)
+		/*channel := slack.GetChannel(c.Slack.ChannelID)
 		if channel == 0 {
 			slack.AddChannel(c.Slack.ChannelID, 2)
 
-		}
+		}*/
 		log.Info("Loaded plugins.", map[string]interface{}{
 			"module":  "main",
 			"plugins": p,

--- a/slack/callbacks.go
+++ b/slack/callbacks.go
@@ -200,6 +200,15 @@ func CreateTagDialog(payload *slack.InteractionCallback) {
 			slack.DialogInputSelect{
 				DialogInput: slack.DialogInput{
 					Type:     "select",
+					Label:    "User/Group to Notify",
+					Name:     "group",
+					Optional: true,
+				},
+				DataSource: "users",
+			},
+			slack.DialogInputSelect{
+				DialogInput: slack.DialogInput{
+					Type:     "select",
 					Label:    "Notification Type",
 					Name:     "notify_type",
 					Optional: false,
@@ -264,6 +273,16 @@ func UpdateTagDialog(payload *slack.InteractionCallback) {
 					Placeholder: tag["channel"].(string),
 				},
 				DataSource: "conversations",
+			},
+			slack.DialogInputSelect{
+				DialogInput: slack.DialogInput{
+					Type:        "select",
+					Label:       "User/Group to Notify",
+					Name:        "group",
+					Optional:    true,
+					Placeholder: tag["group"].(string),
+				},
+				DataSource: "users",
 			},
 			slack.DialogInputSelect{
 				DialogInput: slack.DialogInput{
@@ -368,6 +387,8 @@ func DeleteTag(payload *slack.InteractionCallback) {
 	ChatUpdate(payload, attachment)
 }
 
+// AddChannelCallback takes the response from the `@slab add channel` command
+// and adds a channel to the ChannelList variable
 func AddChannelCallback(payload *slack.InteractionCallback) {
 	log.Info("Adding channel to ChannelList", map[string]interface{}{
 		"module":  "slack",

--- a/slack/channels.go
+++ b/slack/channels.go
@@ -47,6 +47,8 @@ func AddChannel(channel string, chantype int) {
 	}
 }
 
+// LoadPublicChannels asks the datastore for all channels not marked private
+// and adds those channels to the ChannelList
 func LoadPublicChannels() {
 	public, err := datastore.LoadChannels(false)
 	if err != nil {
@@ -56,10 +58,13 @@ func LoadPublicChannels() {
 		})
 	}
 	for _, p := range public {
+
 		ChannelList = append(ChannelList, Channel{ID: p})
 	}
 }
 
+// LoadPrivateChannels asks the datastore for all channels marked private
+// and adds those channels to the DMChannelList
 func LoadPrivateChannels() {
 	private, err := datastore.LoadChannels(true)
 	if err != nil {

--- a/slack/messages.go
+++ b/slack/messages.go
@@ -576,6 +576,11 @@ func ListTagMessage(user *slack.User) {
 					Short: true,
 				},
 				slack.AttachmentField{
+					Title: "Group",
+					Value: fmt.Sprintf("<@%s>", tag["group"]),
+					Short: true,
+				},
+				slack.AttachmentField{
 					Title: "Notification Type",
 					Value: getNotificationType(tag["notify_type"].(string)),
 					Short: true,
@@ -658,6 +663,8 @@ func DeleteTagMessage(user *slack.User, id string) {
 
 }
 
+// ListChannels gets a list of every channel in the ChannelList
+// and sends a DM to the user with that list
 func ListChannels(user string) {
 	log.Info("Listing channels via DM", map[string]interface{}{
 		"module": "slack",
@@ -674,6 +681,8 @@ func ListChannels(user string) {
 	SendDirectMessage(message, attachments, user)
 }
 
+// DMAddChannel shows a list of channels to the user that can be added to the
+// ChannelList for Slab to operate in.,
 func DMAddChannel(user string) {
 	attachment := []slack.Attachment{
 		slack.Attachment{

--- a/slack/messages.go
+++ b/slack/messages.go
@@ -443,7 +443,7 @@ func VerifyUser(user string) bool {
 }
 
 // PrepSLANotification takes a given ticket and what notification level and returns a string to be sent to Slack.
-func PrepSLANotification(ticket Ticket, notify int64, tag string) (notification string, color string) {
+func PrepSLANotification(ticket Ticket, notify int64, tag string, group string) (notification string, color string) {
 	log.Info("Preparing SLA notification message.", map[string]interface{}{
 		"module": "slack",
 		"ticket": ticket.ID,
@@ -467,7 +467,12 @@ func PrepSLANotification(ticket Ticket, notify int64, tag string) (notification 
 		t = "3 hours"
 		c = "#43e0d3"
 	}
-	n = fmt.Sprintf("<!here> SLA for *%s* ticket #%d has less than %s until expiration.", tag, ticket.ID, t)
+
+	if group != "" {
+		n = fmt.Sprintf("<@%s> SLA for *%s* ticket #%d has less than %s until expiration.", group, tag, ticket.ID, t)
+	} else {
+		n = fmt.Sprintf("<!here> SLA for *%s* ticket #%d has less than %s until expiration.", tag, ticket.ID, t)
+	}
 	if notify == 9 {
 		n = fmt.Sprintf("<!here> Expired *%s* SLA! Ticket #%d has an expired SLA.", tag, ticket.ID)
 		c = "danger"


### PR DESCRIPTION
Instead of pinging @here on all SLA notifications, this adds a new configuration field to the tag based notifications, allowing notifications to go to a specific user/group instead of the entire channel. Useful for reporting on SLA notifications to a single group for SLA levels, but also for following tickets related to specific issues