### PR TITLE
comment out reportcaller

### DIFF
--- a/log/log.go
+++ b/log/log.go
@@ -16,7 +16,7 @@ func init() {
 		ForceColors:   true,
 		FullTimestamp: true,
 	}
-	Log.e.SetReportCaller(true)
+	//Log.e.SetReportCaller(true)
 }
 
 func (s *Logger) Fatal(c map[string]interface{}) {


### PR DESCRIPTION
In the slab log files, each line is prefixed with the filename and line number of the function that called the log. The idea was that we could see where in the app was reporting based on the line numbers. The problem is that it's showing the line numbers of the functions in the log package, rather than the functions that are calling it. 